### PR TITLE
Fixed the carousel controls in carousel-default and carousel-caption.

### DIFF
--- a/src/util/resources/bootstrap/components/carousel/caption.html
+++ b/src/util/resources/bootstrap/components/carousel/caption.html
@@ -19,13 +19,20 @@
 				<p>${9:Description}</p>
 			</div>
 		</div>
+		<div class="carousel-item">
+			<img data-src="${10:holder.js/900x500/auto/#666:#444/text:Third slide}" alt="${11:Third slide}">
+			<div class="carousel-caption">
+				<h3>${12:Title}</h3>
+				<p>${13:Description}</p>
+			</div>
+		</div>
 	</div>
-	<a class="left carousel-control" href="#${1:carouselId}" role="button" data-slide="prev">
-		<span class="icon-prev" aria-hidden="true"></span>
+	<a class="carousel-control-prev" href="#${1:carouselId}" role="button" data-slide="prev">
+		<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 		<span class="sr-only">Previous</span>
 	</a>
-	<a class="right carousel-control" href="#${1:carouselId}" role="button" data-slide="next">
-		<span class="icon-next" aria-hidden="true"></span>
+	<a class="carousel-control-next" href="#${1:carouselId}" role="button" data-slide="next">
+		<span class="carousel-control-next-icon" aria-hidden="true"></span>
 		<span class="sr-only">Next</span>
 	</a>
 </div>

--- a/src/util/resources/bootstrap/components/carousel/default.html
+++ b/src/util/resources/bootstrap/components/carousel/default.html
@@ -11,13 +11,16 @@
 		<div class="carousel-item">
 			<img data-src="${4:holder.js/900x500/auto/#666:#444/text:Second slide}" alt="${5:Second slide}">
 		</div>
+		<div class="carousel-item">
+			<img data-src="${6:holder.js/900x500/auto/#666:#444/text:Third slide}" alt="${7:Third slide}">
+		</div>
 	</div>
-	<a class="left carousel-control" href="#${1:carouselId}" role="button" data-slide="prev">
-		<span class="icon-prev" aria-hidden="true"></span>
+	<a class="carousel-control-prev" href="#${1:carouselId}" role="button" data-slide="prev">
+		<span class="carousel-control-prev-icon" aria-hidden="true"></span>
 		<span class="sr-only">Previous</span>
 	</a>
-	<a class="right carousel-control" href="#${1:carouselId}" role="button" data-slide="next">
-		<span class="icon-next" aria-hidden="true"></span>
+	<a class="carousel-control-next" href="#${1:carouselId}" role="button" data-slide="next">
+		<span class="carousel-control-next-icon" aria-hidden="true"></span>
 		<span class="sr-only">Next</span>
 	</a>
 </div>


### PR DESCRIPTION
Made the following changes to carousel-default and carousel-caption template.

1. Updated the carousel control markups according to the latest Bootstrap 4 alpha 6 documentation.
2. Added one more carousel item to match the the number of the carousel indicators.